### PR TITLE
Feature/submission expand

### DIFF
--- a/models/Submission.ts
+++ b/models/Submission.ts
@@ -7,6 +7,7 @@ export interface ISubmission {
 	_id: Types.ObjectId,
 	project: number,
 	author?: string,
+	srcIcon?: string,
 	type: 'image' | 'video' | 'text',
 	src?: string,
 	message?: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hefs-website",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -23,6 +24,7 @@
         "next-auth": "3.23.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "react-infinite-scroll-component": "^6.1.0",
         "react-markdown": "6.0.2",
         "react-player": "2.9.0",
         "rich-markdown-editor": "11.9.1",
@@ -8044,6 +8046,17 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "node_modules/react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "dependencies": {
+        "throttle-debounce": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9311,6 +9324,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/through": {
@@ -16738,6 +16759,14 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "requires": {
+        "throttle-debounce": "^2.1.0"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17838,6 +17867,11 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "next-auth": "3.23.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-markdown": "6.0.2",
     "react-player": "2.9.0",
     "rich-markdown-editor": "11.9.1",

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -66,14 +66,9 @@ export default function ProjectPage() {
 					light
 				/>
 			);
-		} if (doc.media[currentMediaIndex].type === 'image') {
-			return <img className="w-full h-full object-none" src={doc.media[currentMediaIndex].src} alt="" loading="lazy" />;
-		} if (doc.media[currentMediaIndex].type === 'text') {
-			return (
-				<p className="m-4 w-auto h-full overflow-auto whitespace-pre-line text-black dark:text-white dark:text-opacity-80">
-					{doc.media[currentMediaIndex].message}
-				</p>
-			);
+		}
+		if (doc.media[currentMediaIndex].type === 'image') {
+			return <img className="w-full h-full object-contain" src={doc.media[currentMediaIndex].src} alt="" loading="lazy" />;
 		}
 		return <p>Invalid media</p>;
 	}
@@ -86,9 +81,7 @@ export default function ProjectPage() {
 				<div className="w-full max-h-full text-black dark:text-white" key={submission._id as unknown as string}>
 					<div className="w-full flex mt-4 h-14">
 						{submission.srcIcon && (
-							<div className="w-14 h-14 ml-4">
-								<img className="object-cover rounded-full" src={submission.srcIcon} alt="author icon" />
-							</div>
+							<img className="object-cover w-14 h-14 rounded-full" src={submission.srcIcon} alt="author icon" />
 						)}
 						{submission.author && (
 							<div className="text-lg mt-3 ml-4">

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -206,6 +206,25 @@ export default function ProjectPage() {
 									</div>
 								</div>
 							)}
+							{(doc.links?.length ?? 0) > 0 && (
+								<div className="mt-4">
+									<TextHeader text="Links" />
+									<div className="flex justify-center space-x-6 px-4 sm:px-0">
+										{doc.links
+											&& doc.links.map((link, index) => (
+												<div
+													key={`link-${index}` /* eslint-disable-line react/no-array-index-key */}
+													className="rounded-3xl font-bold w-[6rem] h-10 flex items-center justify-center mt-4 content-end
+													bg-skin-secondary-1 dark:bg-skin-dark-secondary-1 text-white hover:text-opacity-70"
+												>
+													<a href={link.link} target="_blank" rel="noreferrer">
+														{link.name}
+													</a>
+												</div>
+											))}
+									</div>
+								</div>
+							)}
 							{/* TODO: Move submissions to separate tab */}
 							{((submissions?.length ?? 0) > 0) && (
 								<div className="mt-4">
@@ -214,25 +233,6 @@ export default function ProjectPage() {
 										<div className="w-full overflow-auto">
 											<Submissions />
 										</div>
-									</div>
-								</div>
-							)}
-							{(doc.links?.length ?? 0) > 0 && (
-								<div className="mt-4">
-									<TextHeader text="Links" />
-									<div className="flex px-4 sm:px-0">
-										{doc.links
-											&& doc.links.map((link, index) => (
-												<div
-													key={`link-${index}` /* eslint-disable-line react/no-array-index-key */}
-													className="rounded-3xl font-bold w-20 h-10 flex items-center justify-center mt-4 content-end mr-4
-													bg-skin-secondary-1 dark:bg-skin-dark-secondary-1 text-white hover:text-opacity-70"
-												>
-													<a href={link.link} target="_blank" rel="noreferrer">
-														{link.name}
-													</a>
-												</div>
-											))}
 									</div>
 								</div>
 							)}

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -12,10 +12,6 @@ import { IProject } from '../../models/Project';
 import { ISubmission } from '../../models/Submission';
 import 'github-markdown-css';
 
-interface SubmissionItemProps {
-	submission: ISubmission,
-}
-
 export default function ProjectPage() {
 	const router = useRouter();
 
@@ -82,62 +78,54 @@ export default function ProjectPage() {
 		return <p>Invalid media</p>;
 	}
 
-	function SubmissionItem({ submission }: SubmissionItemProps) {
-		const { type } = submission;
-		if (type === 'video') {
-			return (
-				<ReactPlayer
-					width="100%"
-					height="100%"
-					url={submission.src}
-					controls
-					light
-					className="mb-4 mt-4"
-				/>
-			);
-		}
-		if (type === 'image') {
-			return (
-				<div className="w-full h-full max-h-[750px] flex justify-center">
-					<img
-						className="w-10/12 object-contain mb-4"
-						src={submission.src}
-						alt=""
-						loading="lazy"
-					/>
-				</div>
-			);
-		}
-		if (type === 'text') {
-			return (
-				<p className="m-4 w-auto h-full overflow-auto whitespace-pre-line text-black dark:text-white dark:text-opacity-80">
-					{submission.message}
-				</p>
-			);
-		}
-		return <p>Invalid media</p>;
-	}
-
 	function Submissions() {
 		// eslint-disable-next-line no-undef
 		const submissionElements: JSX.Element[] = [];
 		submissions.forEach((submission, index) => {
-			const author = (submission.author)
-				? (
-					<h6 className="text-xl left-0 top-0 w-2/3">
-						From:
-						<span className="font-medium">{submission.author}</span>
-					</h6>
-				)
-				: <div className="left-0 top-0 w-2/3" />;
 			submissionElements.push(
-				<div className="w-full max-h-full" key={submission._id as unknown as string}>
-					<div className="w-full mt-4 flex dark:text-gray-200 dark:text-opacity-80">
-						{author}
-						<h6 className="text-xl top-0 right-0 w-1/3 text-right">{`#${index + 1}`}</h6>
+				<div className="w-full max-h-full text-black dark:text-white" key={submission._id as unknown as string}>
+					<div className="w-full flex mt-4 h-14">
+						{submission.srcIcon && (
+							<div className="w-14 h-14 ml-4">
+								<img className="object-cover rounded-full" src={submission.srcIcon} alt="author icon" />
+							</div>
+						)}
+						{submission.author && (
+							<div className="text-lg mt-3 ml-4">
+								From:
+								{' '}
+								<span className="font-bold">{submission.author}</span>
+							</div>
+						)}
+						<div className="flex-grow" />
+						<p className="text-xl mt-3 mr-4">{`#${index + 1}`}</p>
 					</div>
 					<div className="w-full mt-3">
-						<SubmissionItem submission={submission} />
+						{submission.type === 'video' && (
+							<ReactPlayer
+								width="100%"
+								height="100%"
+								url={submission.src}
+								controls
+								light
+								className="mb-4 mt-4"
+							/>
+						)}
+						{submission.type === 'image' && (
+							<div className="mt-4 mb-2 w-full h-full max-h-[750px] flex justify-center">
+								<img
+									className="w-10/12 object-contain mb-4"
+									src={submission.src}
+									alt=""
+									loading="lazy"
+								/>
+							</div>
+						)}
+						{submission.message && (
+							<p className="mx-4 mb-4 w-auto h-full overflow-auto whitespace-pre-line dark:text-gray-300">
+								{submission.message}
+							</p>
+						)}
 						<hr className="border-t-1 border-dashed border-gray-400" />
 					</div>
 				</div>,
@@ -230,7 +218,7 @@ export default function ProjectPage() {
 								<div className="mt-4">
 									<TextHeader text="Submissions" />
 									<div className="flex flex-col items-center pt-2">
-										<div className="w-full max-h-[800px] overflow-auto">
+										<div className="w-full overflow-auto">
 											<Submissions />
 										</div>
 									</div>

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -57,7 +57,7 @@ export default function ProjectPage() {
 		run();
 	}, [router.query]);
 
-	const observer = useRef();
+	const observer = useRef<IntersectionObserver>();
 	const lastSubmissionElementRef = useCallback((node) => {
 		if (observer.current) observer.current.disconnect();
 		observer.current = new IntersectionObserver((entries) => {

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -1,11 +1,10 @@
 import ReactPlayer from 'react-player';
-import {
-	useEffect, useState, useRef, useCallback,
-} from 'react';
+import { useEffect, useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/outline';
 import Error from 'next/error';
 import { useRouter } from 'next/router';
 import ReactMarkdown from 'react-markdown';
+import InfiniteScroll from 'react-infinite-scroll-component';
 import Navbar from '../../components/Navbar';
 import Footer from '../../components/Footer';
 import Header from '../../components/Header';
@@ -57,17 +56,10 @@ export default function ProjectPage() {
 		run();
 	}, [router.query]);
 
-	const observer = useRef<IntersectionObserver>();
-	const lastSubmissionElementRef = useCallback((node) => {
-		if (observer.current) observer.current.disconnect();
-		observer.current = new IntersectionObserver((entries) => {
-			if (entries[0].isIntersecting && shownSubmissions.length < allSubmissions.length) {
-				const newSubLength = shownSubmissions.length + SUBMISSIONS_PER_LOAD;
-				setShownSubmissions(allSubmissions.slice(0, newSubLength));
-			}
-		});
-		if (node) observer.current.observe(node);
-	}, [allSubmissions, shownSubmissions]);
+	const loadMoreSubmissions = () => {
+		const newSubLength = shownSubmissions.length + SUBMISSIONS_PER_LOAD;
+		setShownSubmissions(allSubmissions.slice(0, newSubLength));
+	};
 
 	function CurrentGalleryItem() {
 		if (!doc.media) return <></>;
@@ -93,7 +85,6 @@ export default function ProjectPage() {
 		shownSubmissions.forEach((submission, index) => {
 			submissionElements.push(
 				<div className="w-full max-h-full text-black dark:text-white" key={submission._id as unknown as string}>
-					{index === shownSubmissions.length - 1 && <div ref={lastSubmissionElementRef} />}
 					<div className="w-full flex mt-4 h-14">
 						{submission.srcIcon && (
 							<img className="object-cover w-14 h-14 rounded-full" src={submission.srcIcon} alt="author icon" />
@@ -246,7 +237,15 @@ export default function ProjectPage() {
 									<TextHeader text="Submissions" />
 									<div className="flex flex-col items-center pt-2">
 										<div className="w-full overflow-auto">
-											<Submissions />
+											<InfiniteScroll
+												dataLength={shownSubmissions.length}
+												next={loadMoreSubmissions}
+												hasMore={shownSubmissions.length < allSubmissions.length}
+												loader={<p className="text-black dark:text-white text-center mt-4">Loading...</p>}
+												scrollThreshold="500px"
+											>
+												<Submissions />
+											</InfiniteScroll>
 										</div>
 									</div>
 								</div>


### PR DESCRIPTION
+ submissions will now show an icon if srcIcon? is in data
+ submissions can display image+text now (video+text should also work, just havent tested yet)
+ changed gallery images from object-none to object-contain in order to automatically scale large images to fit the gallery view

- the scroll is now gone, instead stretching the page to display them all. Had to remove because entries started to overlap again, since max-height wasn't enough after adding picture + text. Maybe fine to keep like this until we add proper infinity scroll?