### PR TITLE
Fix: Resolve issue with dashboard description overflow

### DIFF
--- a/components/ProjectEditPage.tsx
+++ b/components/ProjectEditPage.tsx
@@ -629,13 +629,13 @@ export default function ProjectEditPage({ doc }: IProps) {
 								</div>
 								<div className="flex flex-col mt-2">
 									<label htmlFor="description" className="font-bold">Description</label>
-									<div className="flex flex-col justify-start border border-red-300 bg-white max-h-64 rounded-md">
+									<div className="border border-red-300 bg-white min-h-[20vh] max-h-[40vh] rounded-md overflow-auto resize-y">
 										<RichMarkdownEditor
 											onChange={setDescription}
 											id="description"
 											ref={editorRef}
 											defaultValue={'# Welcome\n\nJust an easy to use **Markdown** editor with `slash commands`'}
-											className="rounded-md px-1 w-full overflow-auto"
+											className="rounded-md px-1 w-full"
 										/>
 									</div>
 									<textarea


### PR DESCRIPTION
- Small change to test .git workflow
- Ran into an issue with testing where the scroll overflow of the description container did not reach the top in the project edit page of the dashboard.
- Remove the flex on the container as the centering on the container was causing the scroll to not reach the top.
- For increased QoL, allow the user to resize the y axis of the description div of the project edit page.